### PR TITLE
avoid running Mb function representation multiple times

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+1.3.1 -> 1.4
+- mbCombine and mbSwap require a proxy parameter to avoid
+  running the function representation multiple times
 
 1.2.3 -> 1.2.4
 - exposed NuMatchingObj to the user

--- a/hobbits.cabal
+++ b/hobbits.cabal
@@ -1,5 +1,5 @@
 Name:                hobbits
-Version:             1.3.2
+Version:             1.4
 Synopsis:            A library for canonically representing terms with binding
 
 Description: A library for canonically representing terms with binding via a

--- a/src/Data/Binding/Hobbits/Examples/LambdaLifting.hs
+++ b/src/Data/Binding/Hobbits/Examples/LambdaLifting.hs
@@ -57,13 +57,13 @@ data PeelRet c a where
              PeelRet c (AddArrows lc a)
 
 peelLambdas :: Mb c (Binding (L b) (Term a)) -> PeelRet c (b -> a)
-peelLambdas b = peelLambdasH MNil LType (mbCombine b)
+peelLambdas b = peelLambdasH MNil LType (mbCombine C.typeCtxProxies b)
 
 peelLambdasH ::
   lc ~ (lc0 :> b) => LC lc0 -> LType b -> Mb (c :++: lc) (Term a) ->
                      PeelRet c (AddArrows lc a)
 peelLambdasH lc0 ilt t = case mbMatch t of
-  [nuMP| Lam b |] -> peelLambdasH (lc0 :>: ilt) LType (mbCombine b)
+  [nuMP| Lam b |] -> peelLambdasH (lc0 :>: ilt) LType (mbCombine C.typeCtxProxies b)
   _               -> PeelRet (lc0 :>: ilt) t
 
 

--- a/src/Data/Binding/Hobbits/Examples/LambdaLifting/Terms.hs
+++ b/src/Data/Binding/Hobbits/Examples/LambdaLifting/Terms.hs
@@ -59,7 +59,7 @@ tpretty t = pretty' (emptyMb t) C.empty 0
               Right n' -> "(free-var " ++ show n' ++ ")"
           [nuMP| Lam b |] ->
             let x = "x" ++ show n in
-            "(\\" ++ x ++ "." ++ pretty' (mbCombine b) (varnames :>: (StringF x)) (n+1) ++ ")"
+            "(\\" ++ x ++ "." ++ pretty' (mbCombine C.typeCtxProxies b) (varnames :>: (StringF x)) (n+1) ++ ")"
           [nuMP| App b1 b2 |] ->
             "(" ++ pretty' b1 varnames n ++ " " ++ pretty' b2 varnames n ++ ")"
 
@@ -125,13 +125,13 @@ mdecls_pretty mb_x varnames n = case mbMatch mb_x of
   [nuMP| Decls_Cons decl rest |] ->
     let fname = "F" ++ show n in
     fname ++ " " ++ (mdecl_pretty decl varnames 0) ++ "\n"
-    ++ mdecls_pretty (mbCombine rest) (varnames :>: (StringF fname)) (n+1)
+    ++ mdecls_pretty (mbCombine C.typeCtxProxies rest) (varnames :>: (StringF fname)) (n+1)
 
 mdecl_pretty :: Mb c (Decl a) -> RAssign StringF c -> Int -> String
 mdecl_pretty mb_x varnames n = case mbMatch mb_x of
   [nuMP| Decl_One t|] ->
     let vname = "x" ++ show n in
-    vname ++ " = " ++ mpretty (mbCombine t) (varnames :>: StringF vname)
+    vname ++ " = " ++ mpretty (mbCombine C.typeCtxProxies t) (varnames :>: StringF vname)
   [nuMP| Decl_Cons d|] ->
     let vname = "x" ++ show n in
-    vname ++ " " ++ mdecl_pretty (mbCombine d) (varnames :>: StringF vname) (n+1)
+    vname ++ " " ++ mdecl_pretty (mbCombine C.typeCtxProxies d) (varnames :>: StringF vname) (n+1)

--- a/src/Data/Binding/Hobbits/Internal/Mb.hs
+++ b/src/Data/Binding/Hobbits/Internal/Mb.hs
@@ -58,7 +58,7 @@ data MbTypeRepr a where
     MbTypeReprFun :: MbTypeRepr a -> MbTypeRepr b -> MbTypeRepr (a -> b)
     MbTypeReprData :: MbTypeReprData a -> MbTypeRepr a
 
-data MbTypeReprData a =
+newtype MbTypeReprData a =
     MkMbTypeReprData (NameRefresher -> a -> a)
 
 {-|

--- a/src/Data/Binding/Hobbits/Internal/Name.hs
+++ b/src/Data/Binding/Hobbits/Internal/Name.hs
@@ -158,7 +158,7 @@ fresh_name :: a -> Int
 fresh_name a = unsafePerformIO $ do 
     _dummyRef <- newIORef a
     x <- readIORef counter
-    writeIORef counter (x+1)
+    writeIORef counter $! x+1
     return x
 
 -- -- make one fresh name for each name in a given input list

--- a/src/Data/Binding/Hobbits/Mb.hs
+++ b/src/Data/Binding/Hobbits/Mb.hs
@@ -203,11 +203,13 @@ mbToProxy (MkMbPair _ ns _) = mapRAssign (\_ -> Proxy) ns
 
 {-|
   Take a multi-binding inside another multi-binding and move the
-  outer binding inside the ineer one.
+  outer binding inside the inner one.
 -}
 mbSwap :: RAssign Proxy ctx2 -> Mb ctx1 (Mb ctx2 a) -> Mb ctx2 (Mb ctx1 a)
 mbSwap _ (MkMbPair _ names1 (MkMbPair aRepr names2 a)) =
   MkMbPair (MbTypeReprMb aRepr) names2 (MkMbPair aRepr names1 a)
+mbSwap _ (MkMbPair (MbTypeReprMb aRepr) names1 (MkMbFun px2 f)) =
+  MkMbFun px2 (\names2 -> MkMbPair aRepr names1 (f names2))
 mbSwap proxies2 (ensureFreshFun -> (proxies1, f1)) =
     MkMbFun proxies2
       (\ns2 ->

--- a/src/Data/Binding/Hobbits/Mb.hs
+++ b/src/Data/Binding/Hobbits/Mb.hs
@@ -307,10 +307,9 @@ nuMultiWithElim f args =
 instance Eq a => Eq (Mb ctx a) where
   mb1 == mb2 = mbLiftBool (mbMap2 (==) mb1 mb2)
     where -- the same as 'mbLift' for 'Bool'
-          mbLiftBool :: Mb ctx Bool -> Bool
-          mbLiftBool mb_b = case mbMatch mb_b of
-            MatchedMb _ True -> True
-            MatchedMb _ False -> False
+      mbLiftBool mb_b =
+        case mbMatch mb_b of
+          MatchedMb _ x -> x
 
 
 {-|


### PR DESCRIPTION
previous mbSwap and mbCombine would  run the function
representation of a binding scope multiple times to extract
the proxy representation of the type contexts.