### PR TITLE
Allow building with GHC 9.0

### DIFF
--- a/hobbits.cabal
+++ b/hobbits.cabal
@@ -28,6 +28,7 @@ Library
     , deepseq
     , haskell-src-exts >= 1.17.1 && < 2
     , haskell-src-meta
+    , th-abstraction >= 0.4 && < 0.5
     , th-expand-syns >= 0.3 && < 0.5
     , transformers
     , containers


### PR DESCRIPTION
This applies a couple of tweaks needed to adapt `hobbits` to changes to `template-haskell`'s `TyVarBndr` API in GHC 9.0 (see
[here](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0?version_id=5fcd0a50e0872efb3c38a32db140506da8310d87#template-haskell-217)):

* Since `PlainTV` and `KindedTV` now have an additional field, the `tvName` function from `th-abstraction` is now used to extract the `Name`s from these two constructors. `tvName` is designed to work across different versions of `template-haskell`.
* A use of `TyVarBndr` was changed to `TyVarBndrUnit`. Again, the `th-abstraction` library is used to ensure that `TyVarBndrUnit` is always is in scope, even on old versions of `template-haskell`.
* A use of `PlainTV` was changed to `plainTVSpecified` (offered by `th-abstraction`) to give it a `Specificity` on newer versions of `template-haskell`.