### PR TITLE
Allow building with GHC 9.2

### DIFF
--- a/src/Data/Binding/Hobbits/Internal/Utilities.hs
+++ b/src/Data/Binding/Hobbits/Internal/Utilities.hs
@@ -1,8 +1,10 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE Rank2Types #-}
 
 module Data.Binding.Hobbits.Internal.Utilities where
 
 import qualified Data.Generics as SYB
+import Language.Haskell.TH (Name, Pat(..))
 
 
 
@@ -11,3 +13,10 @@ everywhereButM :: Monad m =>
 everywhereButM q f x
   | q x       = return x
   | otherwise = (SYB.gmapM (everywhereButM q f) x) >>= f
+
+conPCompat :: Name -> [Pat] -> Pat
+conPCompat n pats = ConP n
+#if MIN_VERSION_template_haskell(2,18,0)
+                           []
+#endif
+                           pats

--- a/src/Data/Binding/Hobbits/NuMatching.hs
+++ b/src/Data/Binding/Hobbits/NuMatching.hs
@@ -58,6 +58,7 @@ import Data.Type.RList hiding (map)
 import Data.Binding.Hobbits.Internal.Name
 import Data.Binding.Hobbits.Internal.Mb
 import Data.Binding.Hobbits.Internal.Closed
+import Data.Binding.Hobbits.Internal.Utilities
 
 
 {-| Just like 'mapNamesPf', except uses the NuMatching class. -}
@@ -380,7 +381,7 @@ mkNuMatching tQ =
       getClauses names (NormalC cName cTypes : constrs) =
         do clause <-
              getClauseHelper names (map snd cTypes) (natsFrom 0)
-             (\l -> ConP cName (map (VarP . fst3) l))
+             (\l -> conPCompat cName (map (VarP . fst3) l))
              (\l -> foldl AppE (ConE cName) (map fst3 l))
            clauses <- getClauses names constrs
            return $ clause : clauses
@@ -396,7 +397,7 @@ mkNuMatching tQ =
       getClauses names (InfixC cType1 cName cType2 : constrs) =
         do clause <-
              getClauseHelper names (map snd [cType1, cType2]) (natsFrom 0)
-             (\l -> ConP cName (map (VarP . fst3) l))
+             (\l -> conPCompat cName (map (VarP . fst3) l))
              (\l -> foldl AppE (ConE cName) (map fst3 l))
            clauses <- getClauses names constrs
            return $ clause : clauses
@@ -405,7 +406,7 @@ mkNuMatching tQ =
         do clauses1 <-
              forM cNames $ \cName ->
              getClauseHelper names (map snd cTypes) (natsFrom 0)
-             (\l -> ConP cName (map (VarP . fst3) l))
+             (\l -> conPCompat cName (map (VarP . fst3) l))
              (\l -> foldl AppE (ConE cName) (map fst3 l))
            clauses2 <- getClauses names constrs
            return (clauses1 ++ clauses2)
@@ -508,7 +509,7 @@ mkMkMbTypeReprDataOld conNameQ =
         do clause <-
              getClauseHelper cxt name tyvars locTyvars (map snd cTypes)
              (natsFrom 0)
-             (\l -> ConP cName (map (VarP . fst3) l))
+             (\l -> conPCompat cName (map (VarP . fst3) l))
              (\l -> foldl AppE (ConE cName) (map (VarE . fst3) l))
            clauses <- getClauses cxt name tyvars locTyvars constrs
            return (clause : clauses)
@@ -536,7 +537,7 @@ mkMkMbTypeReprDataOld conNameQ =
         do clauses1 <-
              forM cNames $ \cName ->
              getClauseHelper cxt name tyvars locTyvars (map snd cTypes)
-             (natsFrom 0) (\l -> ConP cName (map (VarP . fst3) l))
+             (natsFrom 0) (\l -> conPCompat cName (map (VarP . fst3) l))
              (\l -> foldl AppE (ConE cName) (map (VarE . fst3) l))
            clauses2 <- getClauses cxt name tyvars locTyvars constrs
            return (clauses1 ++ clauses2)
@@ -572,15 +573,15 @@ mkMkMbTypeReprDataOld conNameQ =
 
       -- FIXME: it is not possible (or, at least, not easy) to determine
       -- if MbTypeRepr a is implied from a current Cxt... so we just add
-      -- everything we need to the returned Cxt, except for 
+      -- everything we need to the returned Cxt, except for
       ensureCxt1 :: Cxt -> [TyVarBndr] -> TH.Type -> CxtStateQ ()
       ensureCxt1 cxt locTyvars t = undefined
       {-
       ensureCxt1 cxt locTyvars t = do
         curCxt = get
         let fullCxt = cxt ++ curCxt
-        isOk <- isMbTypeRepr fullCxt 
+        isOk <- isMbTypeRepr fullCxt
 
-      isMbTypeRepr 
+      isMbTypeRepr
        -}
 -}

--- a/src/Data/Binding/Hobbits/QQ.hs
+++ b/src/Data/Binding/Hobbits/QQ.hs
@@ -43,6 +43,7 @@ import Data.Monoid (Any(..))
 import qualified Data.Binding.Hobbits.Internal.Utilities as IU
 import Data.Binding.Hobbits.Internal.Mb
 import Data.Binding.Hobbits.Internal.Closed
+import Data.Binding.Hobbits.Internal.Utilities
 import Data.Binding.Hobbits.PatternParser (parsePattern)
 import Data.Binding.Hobbits.NuMatching
 
@@ -153,9 +154,9 @@ nuMKit :: TH.Name -> TH.Name -> WrapKit
 nuMKit topVar namesVar = WrapKit {_varView = varView, _asXform = asXform, _topXform = topXform} where
   varView = (VarE 'same_ctx_M `AppE` VarE topVar) `compose`
         (appEMulti (ConE 'MkMbPair) [VarE 'nuMatchingProof, VarE namesVar])
-  asXform p = ViewP (VarE 'mbMatch) (ConP 'MatchedMb [WildP, p])
-  topXform b p = if b then AsP topVar $ ConP 'MatchedMb [VarP namesVar, p]
-                      else ConP 'MatchedMb [WildP, p]
+  asXform p = ViewP (VarE 'mbMatch) (conPCompat 'MatchedMb [WildP, p])
+  topXform b p = if b then AsP topVar $ conPCompat 'MatchedMb [VarP namesVar, p]
+                      else conPCompat 'MatchedMb [WildP, p]
 
 -- | Quasi-quoter for patterns that match over 'MatchedMb', for use with
 -- 'mbMatch'
@@ -168,7 +169,7 @@ nuMP = patQQ "nuMP" $ \s -> do
 -- | Builds a 'WrapKit' for parsing patterns that match over 'Closed'
 clKit :: WrapKit
 clKit = WrapKit {_varView = ConE 'Closed, _asXform = asXform, _topXform = const asXform}
-  where asXform p = ConP 'Closed [p]
+  where asXform p = conPCompat 'Closed [p]
 
 -- | Quasi-quoter for patterns that match over 'Closed', built using 'clKit'
 clP :: QuasiQuoter

--- a/src/Data/Type/RList.hs
+++ b/src/Data/Type/RList.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeOperators, EmptyDataDecls, RankNTypes #-}
+{-# LANGUAGE TypeOperators, EmptyCase, EmptyDataDecls, RankNTypes #-}
 {-# LANGUAGE TypeFamilies, DataKinds, PolyKinds, KindSignatures #-}
 {-# LANGUAGE GADTs, TypeInType, PatternGuards, ScopedTypeVariables #-}
 -- |
@@ -182,6 +182,7 @@ data SplitAtMemberRet f ctx a where
 
 -- | Split an assignment at the point specified by a 'Member' proof
 memberSplitAt :: RAssign f ctx -> Member ctx a -> SplitAtMemberRet f ctx a
+memberSplitAt MNil        member      = case member of {}
 memberSplitAt (ctx :>: x) Member_Base = SplitAtMemberRet ctx x MNil
 memberSplitAt (ctx :>: y) (Member_Step memb) =
   case memberSplitAt ctx memb of


### PR DESCRIPTION
`template-haskell-2.18.0.0` (bundled with GHC 9.2) changes the type of `ConP` such that it now has an additional field representing type applications in patterns (see [the GHC 9.2 Migration Guide](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.2?version_id=63085dd8a5b56370571bda428848e7098765f7f8#template-haskell-218)). This breaks existing uses of `ConP` in `hobbits`, so I have added a `conPCompat` function to work with both the old and new types of `ConP`.

I also fixed an `-Wincomplete-patterns` warning in `memberSplitAt` that was spotted by GHC 9.2's smarter pattern-match coverage checker. As a result, this fixes #6.