### PR TITLE
Make `NuMatchingAny1Proof` an alias for a quantified `NuMatching` constraint

### DIFF
--- a/src/Data/Binding/Hobbits/NuMatchingInstances.hs
+++ b/src/Data/Binding/Hobbits/NuMatchingInstances.hs
@@ -44,10 +44,6 @@ $(mkNuMatching [t| forall a b. NuMatching a => Constant a b |])
 $(mkNuMatching [t| forall f g a. (NuMatchingAny1 f,
                                   NuMatchingAny1 g) => Product f g a |])
 
-instance (NuMatchingAny1 f,
-          NuMatchingAny1 g) => NuMatchingAny1 (Product f g) where
-  nuMatchingAny1Proof = nuMatchingProof
-
 instance (Integral a, NuMatching a) => NuMatching (Ratio a) where
   nuMatchingProof =
     isoMbTypeRepr (\r -> (numerator r, denominator r)) (\(n,d) -> n%d)


### PR DESCRIPTION
Previously, there was a global `INCOHERENT` instance of the form:

```hs
instance {-# INCOHERENT #-} NuMatchingAny1 f => NuMatching (f a) where
  nuMatchingProof = nuMatchingAny1Proof
```

This does not combine well with GHC 9.0+'s Template Haskell splice behavior, where instances written after a top-level declaration splice are not visible to instances written before the splice. In particular, this affects which instances GHC will consider when resolving instance overlap w.r.t. incoherent instances, so if you are not careful with the ordering of instances and TH splices, you can accidentally change the _runtime_ behavior of your program. For more information, see GaloisInc/saw-script#1742 and https://gitlab.haskell.org/ghc/ghc/-/issues/22492.

This patch removes the `INCOHERENT` instance and instead makes `NuMatchingAny1` an alias for a quantified constraint involving `NuMatching`:

```hs
class    (forall a. NuMatching (f a)) => NuMatchingAny1 (f :: k -> Type)
instance (forall a. NuMatching (f a)) => NuMatchingAny1 (f :: k -> Type)
```

(Alternatively, we could have made this a type synonym, but using a class has the advantage of not forcing downstream libraries to enable `QuantifiedConstraints` everywhere that `NuMatchingAny1` is used.)

Aside from this change, the rest of this patch simply deletes `NuMatchingAny1` instances, as the one instance above is the only instance we will ever need now.

Credit goes to Matthew Pickering for helping me identify this issue and for authoring a separate fix. I have tweaked his fix and turned it into this patch, adding him as a co-author in the process.