### PR TITLE
Support building with `mtl-2.3.*` (GHC 9.6)

### DIFF
--- a/src/Data/Binding/Hobbits/NuMatching.hs
+++ b/src/Data/Binding/Hobbits/NuMatching.hs
@@ -45,7 +45,7 @@ import qualified Data.Vector as Vector
 import Language.Haskell.TH hiding (Name, Type(..), cxt, clause)
 import qualified Language.Haskell.TH as TH
 import Language.Haskell.TH.Datatype.TyVarBndr
-import Control.Monad.State
+import Control.Monad (forM)
 import Numeric.Natural
 import Data.Functor.Constant
 import Data.Kind as DK

--- a/src/Data/Type/RList.hs
+++ b/src/Data/Type/RList.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE TypeOperators, EmptyCase, EmptyDataDecls, RankNTypes #-}
 {-# LANGUAGE TypeFamilies, DataKinds, PolyKinds, KindSignatures #-}
-{-# LANGUAGE GADTs, TypeInType, PatternGuards, ScopedTypeVariables #-}
+{-# LANGUAGE GADTs, CPP, PatternGuards, ScopedTypeVariables #-}
+
+#if __GLASGOW_HASKELL__ < 806
+{-# LANGUAGE TypeInType #-}
+#endif
 -- |
 -- Module      : Data.Type.RList
 -- Copyright   : (c) 2016 Edwin Westbrook


### PR DESCRIPTION
`mtl-2.3.*` no longer re-exports `Control.Monad` from `Control.Monad.State`, which breaks some code in `hobbits`. This is easily fixed by tightening up the imports a bit.