### PR TITLE
Support building with `th-abstraction-0.6.*` and `-0.7.*`

### DIFF
--- a/hobbits.cabal
+++ b/hobbits.cabal
@@ -28,7 +28,7 @@ Library
     , deepseq
     , haskell-src-exts >= 1.17.1 && < 2
     , haskell-src-meta
-    , th-abstraction >= 0.4 && < 0.5
+    , th-abstraction >= 0.6 && < 0.7
     , th-expand-syns >= 0.3 && < 0.5
     , transformers
     , containers

--- a/hobbits.cabal
+++ b/hobbits.cabal
@@ -28,7 +28,7 @@ Library
     , deepseq
     , haskell-src-exts >= 1.17.1 && < 2
     , haskell-src-meta
-    , th-abstraction >= 0.6 && < 0.7
+    , th-abstraction >= 0.6 && < 0.8
     , th-expand-syns >= 0.3 && < 0.5
     , transformers
     , containers

--- a/src/Data/Binding/Hobbits/NuMatching.hs
+++ b/src/Data/Binding/Hobbits/NuMatching.hs
@@ -63,7 +63,7 @@ import Data.Binding.Hobbits.Internal.Utilities
 mapNames :: NuMatching a => NameRefresher -> a -> a
 mapNames = mapNamesPf nuMatchingProof
 
-matchDataDecl :: Dec -> Maybe (Cxt, TH.Name, [TyVarBndrUnit], [Con])
+matchDataDecl :: Dec -> Maybe (Cxt, TH.Name, [TyVarBndrVis], [Con])
 matchDataDecl (DataD cxt name tyvars _ constrs _) =
   Just (cxt, name, tyvars, constrs)
 matchDataDecl (NewtypeD cxt name tyvars _ constr _) =


### PR DESCRIPTION
This patch is necessary to build `hobbits` with `template-haskell-2.21.*`, which is bundled with GHC 9.8. In `template-haskell-2.21.*`, the type of the type variable binders in `DataD` and `NewtypeD` changes from `[TyVarBndrUnit]` to `[TyVarBndrSpec]`. Luckily, `th-abstraction-0.6.0.0` backports the `TyVarBndrSpec` data type, so we can update to `TyVarBndrSpec` in `hobbits` without needing any CPP.